### PR TITLE
Pre launch image fix

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,9 +26,3 @@ title = "Michael Gardner - In His Own Words"
   contactPatter = "Send comments, questions and solicitations to"
   ## TODO: Font Decisions
   fonts = []
-
-  
-
-[_build]
-  publishResources = true
-

--- a/layouts/partials/bio.html
+++ b/layouts/partials/bio.html
@@ -6,6 +6,9 @@
         {{ partial "image" (resources.Get "images/avatar.png")}}
         {{ partial "image" (resources.Get "images/avatarNight.png")}}
     </figure>
+    {{$avatars := resources.Match "images/avatar.*"}}
+    {{$Nightmen := resources.Match "images/avatarNight.*"}}
+    <p style="display: none">{{ range $avatars }} {{.Permalink}}{{end}}{{range $Nightmen}}{{.Permalink}}{{end}}</p>
 
     <p>{{ .Site.Params.Bio }}</p>
     <figure>


### PR DESCRIPTION
A little bit of a hacky placeholder fix for avatar images.  It doesn't appear there's a site wide build option to force asset images to be rendered, so for the time being we'll use their permalinks in a hidden paragraph.  Placeholder fix.